### PR TITLE
added support for large files with git lfs.

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.root filter=lfs diff=lfs merge=lfs -crlf


### PR DESCRIPTION
There is an addon for git called git lfs which is bassically build in to git and github nowadays. From what i can see it looks like it is simpler to use than gdrive or any of the other cloud storages. 

@cketter  you can find the discription: https://git-lfs.github.com/
